### PR TITLE
Enhance Privacy: Hide Private Key in Web API & Update Kadena Client

### DIFF
--- a/arch/esp32/esp32.ini
+++ b/arch/esp32/esp32.ini
@@ -49,7 +49,7 @@ lib_deps =
   https://github.com/dbinfrago/libpax.git#3cdc0371c375676a97967547f4065607d4c53fd1
   lewisxhe/XPowersLib@^0.2.6
   https://github.com/meshtastic/ESP32_Codec2.git#633326c78ac251c059ab3a8c430fcdf25b41672f
-  https://github.com/crankkio/mesh-blockchain.git#1318410a27b7d8200af9acc079f9a39bf9bed8e6
+  https://github.com/crankkio/kadena-client-api.git#1.0.1
 
 lib_ignore = 
   segger_rtt

--- a/src/mesh/PhoneAPI.cpp
+++ b/src/mesh/PhoneAPI.cpp
@@ -393,8 +393,13 @@ size_t PhoneAPI::getFromRadio(uint8_t *buf)
             fromRadioScratch.moduleConfig.payload_variant.paxcounter = moduleConfig.paxcounter;
             break;
         case meshtastic_ModuleConfig_wallet_tag:
+            LOG_DEBUG("Send module config: wallet");
             fromRadioScratch.moduleConfig.which_payload_variant = meshtastic_ModuleConfig_wallet_tag;
-            fromRadioScratch.moduleConfig.payload_variant.wallet = moduleConfig.wallet;
+            fromRadioScratch.moduleConfig.payload_variant.wallet.enabled = moduleConfig.wallet.enabled;
+            strncpy(fromRadioScratch.moduleConfig.payload_variant.wallet.public_key, moduleConfig.wallet.public_key,
+                    sizeof(fromRadioScratch.moduleConfig.payload_variant.wallet.public_key));
+            memset(fromRadioScratch.moduleConfig.payload_variant.wallet.private_key, 0,
+                   sizeof(fromRadioScratch.moduleConfig.payload_variant.wallet.private_key));
             break;
         default:
             LOG_ERROR("Unknown module config type %d", config_state);

--- a/src/modules/AdminModule.cpp
+++ b/src/modules/AdminModule.cpp
@@ -876,7 +876,11 @@ void AdminModule::handleGetModuleConfig(const meshtastic_MeshPacket &req, const 
         case meshtastic_AdminMessage_ModuleConfigType_WALLET_CONFIG:
             LOG_INFO("Getting module config: Wallet\n");
             res.get_module_config_response.which_payload_variant = meshtastic_ModuleConfig_wallet_tag;
-            res.get_module_config_response.payload_variant.wallet = moduleConfig.wallet;
+            res.get_module_config_response.payload_variant.wallet.enabled = moduleConfig.wallet.enabled;
+            strncpy(res.get_module_config_response.payload_variant.wallet.public_key, moduleConfig.wallet.public_key,
+                    sizeof(res.get_module_config_response.payload_variant.wallet.public_key));
+            memset(res.get_module_config_response.payload_variant.wallet.private_key, 0,
+                   sizeof(res.get_module_config_response.payload_variant.wallet.private_key));
             break;
         }
 

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 [VERSION]  
 major = 2
 minor = 5
-build = 15.1
+build = 15.2


### PR DESCRIPTION
# Description
This PR includes two key improvements:

1. Privacy Enhancement:
   - Modifies PhoneAPI to only expose wallet enable status and public key
   - Zeros out private key when sending wallet configuration to web clients
   - Maintains API compatibility while protecting sensitive data

2. Kadena Client Update:
   - Updates kadena-client-api to version 1.0.1
   - Reduces gas fees for blockchain transactions
   - Improves cost efficiency for node operations

Technical Changes:
- Modified `src/mesh/PhoneAPI.cpp` to selectively send wallet config
- Updated dependency version in library.json
- Uses `strncpy` and `memset` for secure string handling

Testing:
- Verified web interface still functions with hidden private key
- Confirmed reduced gas fees with updated kadena-client
- Tested wallet operations maintain functionality

Security Impact:
+ Improves security by not exposing private keys via web API
+ No changes to core encryption or key storage